### PR TITLE
Simplified create_confusion_matrix_plot 

### DIFF
--- a/R/create_confusion_matrix_plot.R
+++ b/R/create_confusion_matrix_plot.R
@@ -1,58 +1,38 @@
-#' Creates a confusion matrix plot to compare predicted classes with actual classes
+#' Creates a confusion matrix plot from a confusion matrix table
 #'
-#' This function creates a confusion matrix plot when it is given two vectors, one of the predicted classes and
-#' one of the actual ground truth.
+#' This function takes a confusion matrix table (e.g., from caret::confusionMatrix)
+#' and returns a ggplot visualization.
 #'
-#' @param actual A vector of the ground truth classes
-#' @param predicted_classes A vector of the predicted classes
+#' @param cm_table A table or data frame representing the confusion matrix
+#' (e.g., cm$table from caret::confusionMatrix)
 #'
 #' @return A ggplot object of a confusion matrix
 #' @export
 #'
 #' @importFrom ggplot2 ggplot aes geom_tile geom_text scale_fill_gradient labs theme_minimal theme element_text
-#' @importFrom caret confusionMatrix
-#' 
+#'
 #' @examples
-#' actual <- c(0, 1, 1, 1)
-#' predicted_classes <- c(0, 0, 1, 1)
-#' create_confusion_matrix_plot(actual, predicted_classes)
+#' library(caret)
+#' actual <- factor(c(0, 1, 1, 1))
+#' predicted <- factor(c(0, 0, 1, 1))
+#' cm <- confusionMatrix(predicted, actual)
+#' create_confusion_matrix_plot(cm$table)
 
-create_confusion_matrix_plot <- function(actual, predicted_classes) {
-  if (length(actual) != length(predicted_classes)) {
-    stop("`actual` and `predicted_classes` must have the same length.")
-  }
+create_confusion_matrix_plot <- function(cm_table) {
 
-  if (!is.numeric(actual)) {
-    stop("`actual` must be numeric (0/1).")
-  }
-
-  if (!all(actual %in% c(0, 1))) {
-    stop("`actual` must only contain 0 and 1.")
-  }
-
-  if (!is.numeric(predicted_classes)) {
-    stop("`predicted_classes` must be numeric (0/1).")
-  }
-
-  if (!all(predicted_classes %in% c(0, 1))) {
-    stop("`predicted_classes` must only contain 0 and 1.")
-  }
-
-  actual_f <- factor(actual)
-  pred_f <- factor(as.numeric(as.character(predicted_classes)))
-
-  cm <- confusionMatrix(pred_f, actual_f)
-  conf_df <- as.data.frame(cm$table)
+  # Convert to data frame if needed
+  conf_df <- as.data.frame(cm_table)
   names(conf_df) <- c("Actual", "Predicted", "Freq")
 
-  confusion_plot <- ggplot(conf_df, aes(x = Actual, y = Predicted, fill = Freq)) +
+  # Plot
+  ggplot(conf_df, aes(x = Actual, y = Predicted, fill = Freq)) +
     geom_tile() +
     geom_text(aes(label = Freq), size = 6) +
     scale_fill_gradient(low = "white", high = "steelblue") +
     labs(
-      title = "Confusion Matrix for Logistic Regression",
-      x = "Actual Income (0 = <=50K, 1 = >50K)",
-      y = "Predicted Income"
+      title = "Confusion Matrix",
+      x = "Actual",
+      y = "Predicted"
     ) +
     theme_minimal() +
     theme(
@@ -62,6 +42,4 @@ create_confusion_matrix_plot <- function(actual, predicted_classes) {
       axis.title.y = element_text(size = 16),
       plot.title = element_text(size = 18, face = "bold")
     )
-
-  return(confusion_plot)
 }

--- a/tests/testthat/test-create_confusion_matrix_plot.R
+++ b/tests/testthat/test-create_confusion_matrix_plot.R
@@ -5,60 +5,51 @@ source("../../R/create_confusion_matrix_plot.R")
 
 # Test 1: Simple use case 1 (actual and predicted are exact same)
 test_that("create_confusion_matrix_plot returns a ggplot object", {
-  actual <- c(0, 1, 0, 1)
-  predicted_classes <- c(0, 1, 0, 1)
-  
-  confusion_plot <- create_confusion_matrix_plot(actual, predicted_classes)
-  
+  actual <- factor(c(0, 1, 0, 1))
+  predicted <- factor(c(0, 1, 0, 1))
+
+  cm <- confusionMatrix(predicted, actual)
+  confusion_plot <- create_confusion_matrix_plot(cm$table)
+
   expect_true("ggplot" %in% class(confusion_plot))
 })
 
 # Test 2: Simple use case 2 (actual and predicted are different)
-test_that("confusion matrix plot is created without error on valid input", {
-  actual <- c(0, 1, 0, 1, 1, 0)
-  predicted_classes <- c(0, 1, 0, 0, 1, 1)
-  
+test_that("confusion matrix plot is created without error on valid confusion matrix input", {
+  actual <- factor(c(0, 1, 0, 1, 1, 0))
+  predicted <- factor(c(0, 1, 0, 0, 1, 1))
+
+  cm <- confusionMatrix(predicted, actual)
+
   expect_no_error(
-    create_confusion_matrix_plot(actual, predicted_classes)
+    create_confusion_matrix_plot(cm$table)
   )
 })
 
-# Test 3: Wrong input case 1 (vectors that are not just 0 or 1)
-test_that("error if actual or predicted_classes are not numeric 0/1 vectors", {
+# Test 3: Wrong input case 1 (not a valid confusion matrix structure)
+test_that("error if input is not a valid confusion matrix structure", {
   expect_error(
-    create_confusion_matrix_plot(c("a", "b"), c(0, 1))
-  )
-  
-  expect_error(
-    create_confusion_matrix_plot(c(0, 1), c("x", "y"))
-  )
-  
-  expect_error(
-    create_confusion_matrix_plot(c(0, 2), c(0, 1))
-  )
-  
-  expect_error(
-    create_confusion_matrix_plot(c(0, 1), c(0, 3))
+    create_confusion_matrix_plot(c(1, 2, 3))
   )
 })
 
-# Test 4: Wrong input case 2 (unequal vector lengths)
-test_that("error if actual and predicted_classes have different lengths", {
-  actual <- c(0, 1, 0)
-  predicted_classes <- c(0, 1)
+# Test 4: Wrong input case 2 (not a 2D confusion matrix)
+test_that("error if confusion matrix does not have correct structure", {
+  # 1D table (not 2D confusion matrix)
+  invalid_table <- table(c(0, 1, 1, 0))
   
   expect_error(
-    create_confusion_matrix_plot(actual, predicted_classes)
+    create_confusion_matrix_plot(invalid_table)
   )
 })
 
 # Test 5: Edge case (minimal valid data)
 test_that("function works with minimal valid input", {
-  actual <- c(0, 1)
-  predicted_classes <- c(0, 1)
-  
-  confusion_plot <- create_confusion_matrix_plot(actual, predicted_classes)
-  
+  actual <- factor(c(0, 1))
+  predicted <- factor(c(0, 1))
+
+  cm <- confusionMatrix(predicted, actual)
+  confusion_plot <- create_confusion_matrix_plot(cm$table)
+
   expect_true("ggplot" %in% class(confusion_plot))
 })
-


### PR DESCRIPTION
I made changes to the create_confusion_matrix_plot function as suggested by the feedback recieved in milestone 3. Simplified the function to only plot the confusion matrix and not validate or model the data. Also altered the test to be able to reflect the changes made to the function. 